### PR TITLE
Session IDs are no longer accidently set to participant IDs

### DIFF
--- a/audio-plugin/src/ios/AudioPlugin/AudioPlugin/AudioPlugin.m
+++ b/audio-plugin/src/ios/AudioPlugin/AudioPlugin/AudioPlugin.m
@@ -67,11 +67,13 @@
     LPCProfileDescription *description;
     NSDictionary *accountAsDict = [command argumentAtIndex:0 withDefault:nil andClass:[NSDictionary class]];
 	NSString *userString = [command argumentAtIndex:1 withDefault:@"" andClass:[NSString class]];
+    NSString *recordingSessionId = [command argumentAtIndex:2 withDefault:@"INVALID-ID" andClass:[NSString class]];
     if (accountAsDict) {
         description = [LPCProfileDescription accountDescriptionWithDictionary:accountAsDict];
         LPCRecordingSession *session = [LPCRecordingSession
 										sessionWithProfileDescription:description
-										clientUserData:userString];
+										clientUserData:userString
+                                        recordingSessionId:recordingSessionId];
         [self.audioManager startRecordingForRecordingSession:session];
         NSDictionary *recordingFiles = [session recordingFilesDictionary];
         CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK

--- a/audio-plugin/src/ios/AudioPlugin/AudioPlugin/LPCRecordingSession.h
+++ b/audio-plugin/src/ios/AudioPlugin/AudioPlugin/LPCRecordingSession.h
@@ -20,7 +20,7 @@ FOUNDATION_EXPORT NSString *const LPCRecordingSessionAudioKey;
 @property (nonatomic, readonly) NSString *lpcFilename;
 @property (nonatomic, readonly) NSString *audioFilename;
 
-+ (instancetype) sessionWithProfileDescription:(LPCProfileDescription *)profile clientUserData:(NSString *)userDataString;
++ (instancetype) sessionWithProfileDescription:(LPCProfileDescription *)profile clientUserData:(NSString *)userDataString recordingSessionId:(NSString *)recordingSessionId;
 + (instancetype) sessionWithMetadataFile:(NSString *)metadata;
 + (NSArray<LPCRecordingSession *> *) recordingsForAccount:(LPCProfileDescription *)profile;
 + (NSString *) recordingDirectory;

--- a/audio-plugin/src/ios/AudioPlugin/AudioPlugin/LPCRecordingSession.m
+++ b/audio-plugin/src/ios/AudioPlugin/AudioPlugin/LPCRecordingSession.m
@@ -37,7 +37,7 @@ NSString *const LPCRecordingSessionAudioKey = @"Audio";
     return dateFormatter;
 }
 
-+ (instancetype) sessionWithProfileDescription:(LPCProfileDescription *)profile clientUserData:(NSString *)userDataString
++ (instancetype) sessionWithProfileDescription:(LPCProfileDescription *)profile clientUserData:(NSString *)userDataString recordingSessionId:(NSString *)recordingSessionId
 {
     LPCRecordingSession *session = [[LPCRecordingSession alloc] init];
     session.profileDescription = profile;
@@ -51,9 +51,9 @@ NSString *const LPCRecordingSessionAudioKey = @"Audio";
 	
     session.dateString = [dateFormatter stringFromDate:session.date];
 	session.endDateString = @"";
-    session.metadataFilename = [NSString stringWithFormat:@"%@-%@-meta.csv", session.profileDescription.uuid, session.dateString];
-    session.lpcFilename = [NSString stringWithFormat:@"%@-%@-lpc.csv", session.profileDescription.uuid, session.dateString];
-    session.audioFilename = [NSString stringWithFormat:@"%@-%@-audio.m4a", session.profileDescription.uuid, session.dateString];
+    session.metadataFilename = [NSString stringWithFormat:@"%@-%@-meta.csv", recordingSessionId, session.dateString];
+    session.lpcFilename = [NSString stringWithFormat:@"%@-%@-lpc.csv", recordingSessionId, session.dateString];
+    session.audioFilename = [NSString stringWithFormat:@"%@-%@-audio.m4a", recordingSessionId, session.dateString];
     
     return session;
 }

--- a/audio-plugin/www/audioplugin.js
+++ b/audio-plugin/www/audioplugin.js
@@ -20,13 +20,13 @@ module.exports = {
                  "getLPCCoefficients",
                  null); // No arguments
   },
-  startRecording: function(profileDescription, userString, successCallback, errorCallback) {
+  startRecording: function(profileDescription, userString, recordingSessionId, successCallback, errorCallback) {
     cordova.exec(
       successCallback,
       errorCallback,
       "AudioPlugin",
       "startRecording",
-      [profileDescription, userString]
+      [profileDescription, userString, recordingSessionId]
     );
   },
   stopRecording: function(successCallback, errorCallback) {

--- a/staRt/www/common-components/practice-directive/practice-directive_controller.js
+++ b/staRt/www/common-components/practice-directive/practice-directive_controller.js
@@ -513,7 +513,7 @@ practiceDirective.controller( 'PracticeDirectiveController',
 
     sessionPrepTask.then(function () {
       if (window.AudioPlugin !== undefined) {
-        AudioPlugin.startRecording(user, sessionDisplayString(), recordingDidStart, recordingDidFail);
+        AudioPlugin.startRecording(user, sessionDisplayString(),  $scope.currentPracticeSession.id, recordingDidStart, recordingDidFail);
       }
       advanceWord();
     });


### PR DESCRIPTION
This bug was detected because we were noticing the upload feature
was not always working, and that sometimes files were being marked
as uploaded when they were not in fact uploaded. The issue was that
in the AudioPlugin, the uuid that is associated to a Participant
was being confused with the uuid that is associated with a specific
recording session. Consequently, the file names associated with the
audio recordings, rating data, and lpc were prefixed with the uuid
of the user. Since the prefix of the file names are used to determine
the session id, many different audio files have the same session id.

The consequence of this is a little bit confusing. There may be a
considerable number of audio files that are currently uploaded to the
server that are not being displayed on the interface. This is because
although the session ids are not unique, the date-time in the file name makes
the files unique, so if you go through the uploads folder / aws you will
see more audio files than there are uploads on the table displayed on the webpage.
So there is an opportunity for recovering everything that was lossed from this
bug, but it would take a little bit of work.