### PR TITLE
Fixed functions that were not top level to use the var name = functio…

### DIFF
--- a/staRt/www/common-components/practice-directive/practice-directive_controller.js
+++ b/staRt/www/common-components/practice-directive/practice-directive_controller.js
@@ -159,10 +159,10 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 	function handleRatingData($scope, data) {
 
 		// adative difficulty helpers
-		function should_increase_difficulty() {return performance >= increase_difficulty_threshold && $scope.difficulty < 5;}
-		function should_decrease_difficulty() {return performance <= decrease_difficulty_threshold && $scope.difficulty > 1;}
+		var should_increase_difficulty = function() {return performance >= increase_difficulty_threshold && $scope.difficulty < 5;};
+		var should_decrease_difficulty = function() {return performance <= decrease_difficulty_threshold && $scope.difficulty > 1;};
 
-		function update_difficulty(increment) {
+		var update_difficulty = function(increment) {
 			$scope.difficulty += increment;
 			console.log($scope.difficulty);
 			if (!($scope.type == 'Syllable' || $scope.probe)) {
@@ -176,7 +176,7 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 				return $scope.reloadCSVData();
 			}
 			return Promise.resolve();
-		}
+		};
 
 		// process new rating
 		if (!$scope.probe) { //quest

--- a/staRt/www/common-components/practice-directive/practice-directive_questScoring.js
+++ b/staRt/www/common-components/practice-directive/practice-directive_questScoring.js
@@ -112,13 +112,13 @@ practiceDirective.factory('QuestScore', function QuestScoreFactory() {
 		milestones = undefined;
 		milestones = new Milestones();
 
-		function mapHighscores(milestone) {
+		var mapHighscores = function(milestone) {
 			var highscoresArr = highscores[milestone + 'Hx'].map(function(item) {
 				return item.score;
 			});
 			//return(Math.max(...highscoresArr)); (won't work on iOS9?)
 			return(Math.max.apply(Math, highscoresArr));
-		}
+		};
 
 		for (var key in milestones.highscores) {
 			milestones.highscores[key] = mapHighscores(key);


### PR DESCRIPTION
…n()...

declaration syntax. This is done because the other declaration syntax
will cause issues on old versions of ios.