### PR TITLE
We now ask the user if they would like to upload their session before…

### DIFF
--- a/staRt/www/common-components/practice-directive/practice-directive_controller.js
+++ b/staRt/www/common-components/practice-directive/practice-directive_controller.js
@@ -370,13 +370,6 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 		if (doStoreFormalSession) {
 			console.log('storing formal session');
 			AutoService.pauseSession(); // TODO: Perhaps set category restrictions to null.
-			if ($scope.skipUploadQuestion) {
-				$cordovaDialogs.alert(
-					'You quit midway through a session. You can resume the formal session by going to the Profiles->profile page and clicking Start Session.',
-					'Resume Session',
-					'Okay'
-				);
-			}
 			var currentPracticeSessionCopy = Object.assign({}, $scope.currentPracticeSession);
 			ProfileService.runTransactionForCurrentProfile(function(handle, doc, t) {
 				t.update(handle, { inProcessSession: currentPracticeSessionCopy });
@@ -389,7 +382,17 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 		}
 
 
-		if (!$scope.skipUploadQuestion) {
+		if ($scope.homeScreenClicked) {
+			var resumeMessage = 'Hey, looks like you quit staRt mid session! You can resume quizzes and quests by going to the recordings section on the Profiles page.';
+			if (doStoreFormalSession) {
+				resumeMessage = 'You quit midway through a session. You can resume the formal session by going to the Profiles->profile page and clicking Start Session.';
+			}
+			$cordovaDialogs.alert(
+				resumeMessage,
+				'Session Interrupted',
+				'Got it!'
+			).then(function() {$state.go($scope.recordingStoppedDestination);});
+		} else {
 			storeTask.then(function() {
 				if (doUpload) {
 					saveJSON($scope.currentPracticeSession.ratings, jsonPath, function () {
@@ -637,16 +640,8 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 
 	$rootScope.onPause = function () {
 		$scope.active = false;
-		$scope.skipUploadQuestion = true;
-		$scope.endWordPractice();
-		$state.go('root.profiles');
-		if (!AutoService.isSessionActive()) {
-			$cordovaDialogs.alert(
-				'Hey, looks like you quit staRt mid session! You can resume quizzes and quests by going to the recordings section on the Profiles page.',
-				'Session Interrupted',
-				'Got it!'
-			);
-		}
+		$scope.homeScreenClicked = true;
+		$rootScope.endSessionAndGo('root.profiles');
 	};
 
 	$rootScope.onResume = function () {

--- a/staRt/www/common-components/practice-directive/practice-directive_controller.js
+++ b/staRt/www/common-components/practice-directive/practice-directive_controller.js
@@ -411,13 +411,16 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 									);
 									$scope.uploadStatus.isUploading = true;
 								}
+								if ($scope.redirectAfterSession) {
+									$state.go($scope.recordingStoppedDestination);
+								}
 							}, 'Upload',
 							['Okay', 'Later']);
 					});
 				}
 			});
 		}
-	  $rootScope.isRecording = false;
+		$rootScope.isRecording = false;
 	}
 
 	function setQuizType_graphics() {
@@ -795,6 +798,12 @@ practiceDirective.controller( 'PracticeDirectiveController', function($scope, $t
 	});
 
 	$scope.myURL = $state.current.name;
+
+	$rootScope.endSessionAndGo = function (destination) {
+		$scope.redirectAfterSession = true;
+		$scope.recordingStoppedDestination = destination;
+		$scope.endWordPractice();
+	};
 
 	var unsubscribe = $rootScope.$on('$urlChangeStart', function (event, next) {
 		if (next === $scope.myURL) {

--- a/staRt/www/states/root/root_controller.js
+++ b/staRt/www/states/root/root_controller.js
@@ -29,8 +29,9 @@
 				navigator.notification.confirm('Are you sure you would like to leave this session?',
 					function (index) {
 						if (index === 1 ) {
-							$state.go('root.' + destination);
-						}}, 'Quit Session?',
+							$rootScope.endSessionAndGo('root.' + destination);
+						}
+					}, 'Quit Session?',
 					['Leave Session', 'Stay']);
 			}
 			else {


### PR DESCRIPTION
… we navigate them away from the quest/quiz page.

This is a nice user experience and also prevents the bug where ng-click events are fired twice, as reported by Yuhan with
ratings during quizzes. There is further work that can be done here. When a quiz or quest is complete, we may want to have
a splash screen that says "quest/quiz complete!" instead of having the background be the beginning of the quest/quiz page.
Also, when we click "okay" after uploading, I don't think we should have nothing happen and then all of the sudden a popup
comes in later saying "Upload Complete." Imo we should have something in the top right corner of the screen
saying uploading files... and when that is completed it shows a check mark and then fades away.